### PR TITLE
Change behavior of magma implementation on invalid labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # sorting
-code and theory for various sorting schemes
+Magma/PariGP/SageMath Code associated to the paper [*Sorting and labelling integral ideals in a number field*](https://arxiv.org/abs/2005.09491), by John Cremona, Aurel Page, and Andrew V. Sutherland.

--- a/code/sorting.m
+++ b/code/sorting.m
@@ -185,7 +185,7 @@ function IdealFromNormIndex(K,n,m)
     end if;
     pp:=[p[1]^p[2]:p in Factorization(n)];
     Q:=<IdealsOfPrimePowerNorm(K,q):q in pp>;
-    for S in Q do if #S eq 0 then return 0; end if; end for;
+    for S in Q do error if #S eq 0, Sprintf("No ideal with  norm %o and index %o exists in the number field %o", n, m, K); end for;
     a := m-1;
     for j:=#Q to 1 by -1 do
         i:=a mod #Q[j];


### PR DESCRIPTION
This PR changes the behavior of `IdealFromLabel` so that it raises an error rather than returning 0 when no labels of the specified norm exist.